### PR TITLE
Ollama and Groq Models Through Native Bindings

### DIFF
--- a/src/marimo_notebook/modules/groq.py
+++ b/src/marimo_notebook/modules/groq.py
@@ -1,6 +1,10 @@
 from typing import Iterator, Optional, Dict, Type, List
 from llm import Model, Prompt, Response, Conversation
 from groq import Groq
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
 
 class GroqModel(Model):
     model_id: str
@@ -67,13 +71,11 @@ class Options(Model.Options):
     top_p: Optional[float] = 1.0
     # Add other Groq-specific parameters as needed
 
-
+client = Groq(api_key=os.getenv("GROQ_API_KEY"))
 SUPPORTED_MODELS = [
-    "mixtral-8x7b-32768",
-    "llama-3.3-70b-versatile",
-    "gemma2-9b-it",
-    "llama-3.1-8b-instant",
+    model.id for model in client.models.list().data
 ]
+client = None;
 
 _models: Dict[str, Type[GroqModel]] = {}
 

--- a/src/marimo_notebook/modules/groq.py
+++ b/src/marimo_notebook/modules/groq.py
@@ -1,0 +1,101 @@
+from typing import Iterator, Optional, Dict, Type, List
+from llm import Model, Prompt, Response, Conversation
+from groq import Groq
+
+class GroqModel(Model):
+    model_id: str
+    needs_key: str = "Groq API key"
+    key_env_var: str = "GROQ_API_KEY"
+    can_stream: bool = True
+
+    def __init__(self, model_id: str = "mixtral-8x7b-32768", **kwargs):
+        self.model_id = model_id
+        self.client = None
+        super().__init__(**kwargs)
+
+    def _ensure_client(self):
+        if self.client is None:
+            if not self.key:
+                raise ValueError("Groq API key is required")
+            self.client = Groq(api_key=self.key)
+
+    def execute(
+        self,
+        prompt: Prompt,
+        stream: bool,
+        response: Response,
+        conversation: Optional[Conversation],
+    ) -> Iterator[str]:
+        self._ensure_client()
+
+        messages = []
+        if prompt.system:
+            messages.append({"role": "system", "content": prompt.system})
+        
+        # Handle conversation history if present
+        if conversation and conversation.messages:
+            for msg in conversation.messages:
+                role = "assistant" if msg.type == "response" else "user"
+                messages.append({"role": role, "content": msg.prompt.prompt})
+
+        # Add the current prompt
+        messages.append({"role": "user", "content": prompt.prompt})
+
+        completion = self.client.chat.completions.create(
+            model=self.model_id,
+            messages=messages,
+            stream=stream,
+            temperature=prompt.options.get("temperature", 0.7),
+            max_tokens=prompt.options.get("max_tokens", None),
+        )
+
+        if stream:
+            for chunk in completion:
+                if chunk.choices[0].delta.content:
+                    yield chunk.choices[0].delta.content
+        else:
+            yield completion.choices[0].message.content
+
+        # Store usage information if available
+        if hasattr(completion, "usage"):
+            response.prompt_tokens = completion.usage.prompt_tokens
+            response.completion_tokens = completion.usage.completion_tokens
+
+class Options(Model.Options):
+    temperature: Optional[float] = 0.7
+    max_tokens: Optional[int] = None
+    top_p: Optional[float] = 1.0
+    # Add other Groq-specific parameters as needed
+
+
+SUPPORTED_MODELS = [
+    "mixtral-8x7b-32768",
+    "llama-3.3-70b-versatile",
+    "gemma2-9b-it",
+    "llama-3.1-8b-instant",
+]
+
+_models: Dict[str, Type[GroqModel]] = {}
+
+def get_model(model_name: str) -> "GroqModel":
+    """
+    Get a Groq model instance by name.
+    
+    Args:
+        model_name: Name of the Groq model to use (e.g., "mixtral-8x7b-32768", "llama2-70b-4096")
+    
+    Returns:
+        GroqModel: An instance of GroqModel configured for the specified model
+    
+    Raises:
+        ValueError: If the model name is not recognized
+    """
+    if model_name not in SUPPORTED_MODELS:
+        raise ValueError(
+            f"Unknown model: {model_name}. "
+            f"Supported models are: {', '.join(SUPPORTED_MODELS)}"
+        )
+    return GroqModel(model_id=model_name)
+
+
+

--- a/src/marimo_notebook/modules/ollama.py
+++ b/src/marimo_notebook/modules/ollama.py
@@ -1,0 +1,87 @@
+from typing import Iterator, Optional, Dict, Type, List
+from llm import Model, Prompt, Response, Conversation
+import ollama
+
+class OllamaModel(Model):
+    model_id: str
+    needs_key: str = None  # Ollama doesn't need an API key
+    key_env_var: str = None
+    can_stream: bool = True
+
+    def __init__(self, model_id: str = "mistral", **kwargs):
+        self.model_id = model_id
+        super().__init__(**kwargs)
+
+    def execute(
+        self,
+        prompt: Prompt,
+        stream: bool,
+        response: Response,
+        conversation: Optional[Conversation],
+    ) -> Iterator[str]:
+        messages = []
+        if prompt.system:
+            messages.append({"role": "system", "content": prompt.system})
+        
+        # Handle conversation history if present
+        if conversation and conversation.messages:
+            for msg in conversation.messages:
+                role = "assistant" if msg.type == "response" else "user"
+                messages.append({"role": role, "content": msg.prompt.prompt})
+
+        # Add the current prompt
+        messages.append({"role": "user", "content": prompt.prompt})
+
+        # Access options directly instead of using .get()
+        options = {
+            "temperature": getattr(prompt.options, "temperature", 0.7),
+            "num_predict": getattr(prompt.options, "max_tokens", None),
+            "top_p": getattr(prompt.options, "top_p", 1.0),
+        }
+
+        completion = ollama.chat(
+            model=self.model_id,
+            messages=messages,
+            stream=stream,
+            options=options,
+        )
+
+        if stream:
+            for chunk in completion:
+                if chunk.get("message", {}).get("content"):
+                    yield chunk["message"]["content"]
+        else:
+            yield completion["message"]["content"]
+
+class Options(Model.Options):
+    temperature: Optional[float] = 0.7
+    max_tokens: Optional[int] = None
+    top_p: Optional[float] = 1.0
+    # Add other Ollama-specific parameters as needed
+
+SUPPORTED_MODELS = [model['name'] for model in ollama.list().get('models', [])]
+
+_models: Dict[str, Type[OllamaModel]] = {}
+
+def get_model(model_name: str) -> "OllamaModel":
+    """
+    Get an Ollama model instance by name.
+    
+    Args:
+        model_name: Name of the Ollama model to use (e.g., "mistral", "llama2")
+    
+    Returns:
+        OllamaModel: An instance of OllamaModel configured for the specified model
+    
+    Raises:
+        ValueError: If the model name is not recognized
+    """
+    if model_name not in SUPPORTED_MODELS:
+        raise ValueError(
+            f"Unknown model: {model_name}. "
+            f"Supported models are: {', '.join(SUPPORTED_MODELS)}"
+        )
+    return OllamaModel(model_id=model_name)
+
+
+


### PR DESCRIPTION
Without installing plugins the `llm` methods were limiting to either OpenAI or OpenAI compatible services. To add more seamless support for Ollama and Groq(cloud) I added bridges that interface directly with the Python SDKs for the services.